### PR TITLE
增加获取url和header授权签名方法

### DIFF
--- a/oss/generateSign.go
+++ b/oss/generateSign.go
@@ -1,0 +1,64 @@
+package oss
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"hash"
+	"io"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Compositions struct {
+	Xossmap         map[string]string
+	Date            string
+	ContentType     string
+	ContentMd5      string
+	AccessKeySecret string
+	Method          string //GET POST PUT DELETE...
+}
+
+//GenerateSign 生成签名方法（返回签名url或header方式的签名字符串）.
+func GenerateSign(flag int, canonicalizedResource string, compositions *Compositions) (string, error) {
+	// 找出“x-oss——”在此请求'header的地址
+	temp := make(map[string]string)
+
+	for k, v := range compositions.Xossmap {
+		if strings.HasPrefix(strings.ToLower(k), "x-oss-") {
+			//检查前缀转换小写key 置入map temp
+			temp[strings.ToLower(k)] = v
+		}
+	}
+	//head store
+	hs := newHeaderSorter(temp)
+
+	// 升序排序
+	hs.Sort()
+
+	// Get the CanonicalizedOSSHeaders
+	//所有以 x-oss- 为前缀的HTTP Header被称为CanonicalizedOSSHeaders
+	canonicalizedOSSHeaders := ""
+	for i := range hs.Keys {
+		canonicalizedOSSHeaders += hs.Keys[i] + ":" + hs.Vals[i] + "\n"
+	}
+
+	// Give other parameters values
+	date := compositions.Date               //"Date"
+	contentType := compositions.ContentType //"Content-Type"
+	contentMd5 := compositions.ContentMd5   //"Content-MD5"
+	time.Now()
+	signStr := compositions.Method + "\n" + contentMd5 + "\n" + contentType + "\n" + date + "\n" + canonicalizedOSSHeaders + canonicalizedResource
+	h := hmac.New(func() hash.Hash { return sha1.New() }, []byte(compositions.AccessKeySecret))
+	io.WriteString(h, signStr)
+	signedStr := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	var result string
+	if flag == 1 { //url sign
+		URL, _ := url.Parse(signedStr)
+		result = url.QueryEscape(URL.String())
+	} else { //header sign
+		result = "OSS " + "LTAINwY5Hri5wwQL" + ":" + signedStr
+	}
+	return result, nil
+}

--- a/oss/generateSign_test.go
+++ b/oss/generateSign_test.go
@@ -1,0 +1,67 @@
+package oss
+
+import "testing"
+import "fmt"
+
+func TestGenerateSign(t *testing.T) {
+
+	compositions1 := &Compositions{
+		Method:          "GET",
+		Date:            "1493989264",
+		AccessKeySecret: "6edKtOCgTV5XDCrVTqHgHA9pgtWRi8",
+	}
+	compositions2 := &Compositions{
+		Method:          "GET",
+		Date:            "Thu, 04 May 2017 10:50:23 GMT",
+		AccessKeySecret: "we32tOCgTV5XDCretqHgHA9pdwrRi8",
+	}
+
+	type args struct {
+		flag                  int
+		canonicalizedResource string
+		compositions          *Compositions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "1",
+			args: args{
+				flag: 1,
+				canonicalizedResource: "/test/0000000001/0000000001.20151018.3b3e9730-7541-11e5-9480-2f80e994f28c.json",
+				compositions:          compositions1,
+			},
+			want:    "wfJvYphml7qGtYLO9Up4UikxW0E%3D",
+			wantErr: false,
+		}, {
+			name: "2",
+			args: args{
+				flag: 2,
+				canonicalizedResource: "/test/0000000001/0000000001.20151018.3b3e9730-7541-11e5-9480-2f80e994f28c.json",
+				compositions:          compositions2,
+			},
+			want:    "OSS LTAINwY5Hri5wwQL:ClnfeWr0AFc6MyduDbyS4E1TZFM=",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateSign(tt.args.flag, tt.args.canonicalizedResource, tt.args.compositions)
+			if err != nil {
+				t.Errorf("GenerateSign() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			fmt.Println(got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateSign() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GenerateSign() = %v, want %v", got, tt.want)
+			}
+			t.Log("test case ok!")
+		})
+	}
+}


### PR DESCRIPTION
最近公司的项目有个获取sign的需求，于是自己根据文档和auth源码做了下，包括获取url的sign和header两种方式的sign，方便前端直接在http header或url中直接提交请求资源