### PR TITLE
修复在分片下载的协程中，因为关闭文件不及时造成的最后完成rename时提示文件被占用的错误

### DIFF
--- a/oss/download.go
+++ b/oss/download.go
@@ -113,22 +113,26 @@ func downloadWorker(id int, arg downloadWorkerArg, jobs <-chan downloadPart, res
 
 		fd, err := os.OpenFile(arg.filePath, os.O_WRONLY, FilePermMode)
 		if err != nil {
+			fd.Close()
 			failed <- err
 			break
 		}
-		defer fd.Close()
 
 		_, err = fd.Seek(part.Start-part.Offset, os.SEEK_SET)
 		if err != nil {
+			fd.Close()
 			failed <- err
 			break
 		}
 
 		_, err = io.Copy(fd, rd)
 		if err != nil {
+			fd.Close()
 			failed <- err
 			break
 		}
+
+		fd.Close()
 
 		results <- part
 	}


### PR DESCRIPTION
使用断点续传多线程方式下载文件，线上使用后发现，经常会出现rename  xxx.zip.temp  yyy.zip:the process cannot access the file because it is being used by another process  的错误导致下载失败
temp文件已经下载成功，但是最后重命名Rename的时候会出现这个错误

发现在下载分片的协程中，使用了defer来进行temp文件描述符的关闭，这样可能会造成多分片的情况下，result 管道已经通知，但是temp的fd还未及时关闭，很大概率会导致rename时出现文件被占用