### PR TITLE
Add IdleConnTimeout for Transport

### DIFF
--- a/oss/bucket_test.go
+++ b/oss/bucket_test.go
@@ -1765,6 +1765,7 @@ func (s *OssBucketSuite) TestGetConfig(c *C) {
 	c.Assert(bucket.getConfig().HTTPTimeout.ConnectTimeout, Equals, time.Second*11)
 	c.Assert(bucket.getConfig().HTTPTimeout.ReadWriteTimeout, Equals, time.Second*12)
 	c.Assert(bucket.getConfig().HTTPTimeout.HeaderTimeout, Equals, time.Second*12)
+	c.Assert(bucket.getConfig().HTTPTimeout.IdleConnTimeout, Equals, time.Second*12)
 	c.Assert(bucket.getConfig().HTTPTimeout.LongTimeout, Equals, time.Second*12*10)
 
 	c.Assert(bucket.getConfig().SecurityToken, Equals, "token")

--- a/oss/client.go
+++ b/oss/client.go
@@ -701,6 +701,8 @@ func Timeout(connectTimeoutSec, readWriteTimeout int64) ClientOption {
 			time.Second * time.Duration(readWriteTimeout)
 		client.Config.HTTPTimeout.HeaderTimeout =
 			time.Second * time.Duration(readWriteTimeout)
+		client.Config.HTTPTimeout.IdleConnTimeout =
+			time.Second * time.Duration(readWriteTimeout)
 		client.Config.HTTPTimeout.LongTimeout =
 			time.Second * time.Duration(readWriteTimeout*10)
 	}

--- a/oss/client_test.go
+++ b/oss/client_test.go
@@ -1400,6 +1400,7 @@ func (s *OssClientSuite) TestClientOption(c *C) {
 	c.Assert(client.Conn.config.HTTPTimeout.ConnectTimeout, Equals, time.Second*11)
 	c.Assert(client.Conn.config.HTTPTimeout.ReadWriteTimeout, Equals, time.Second*12)
 	c.Assert(client.Conn.config.HTTPTimeout.HeaderTimeout, Equals, time.Second*12)
+	c.Assert(client.Conn.config.HTTPTimeout.IdleConnTimeout, Equals, time.Second*12)
 	c.Assert(client.Conn.config.HTTPTimeout.LongTimeout, Equals, time.Second*12*10)
 
 	c.Assert(client.Conn.config.SecurityToken, Equals, "token")

--- a/oss/conf.go
+++ b/oss/conf.go
@@ -10,6 +10,7 @@ type HTTPTimeout struct {
 	ReadWriteTimeout time.Duration
 	HeaderTimeout    time.Duration
 	LongTimeout      time.Duration
+	IdleConnTimeout  time.Duration
 }
 
 // Config oss configure
@@ -52,6 +53,7 @@ func getDefaultOssConfig() *Config {
 	config.HTTPTimeout.ReadWriteTimeout = time.Second * 60 // 60s
 	config.HTTPTimeout.HeaderTimeout = time.Second * 60    // 60s
 	config.HTTPTimeout.LongTimeout = time.Second * 300     // 300s
+	config.HTTPTimeout.IdleConnTimeout = time.Second * 50  // 50s, nginx的IdleConnTimeout为60s
 
 	config.IsUseProxy = false
 	config.ProxyHost = ""

--- a/oss/conn.go
+++ b/oss/conn.go
@@ -30,19 +30,8 @@ var signKeyList = []string{"acl", "uploads", "location", "cors", "logging", "web
 
 // init 初始化Conn
 func (conn *Conn) init(config *Config, urlMaker *urlMaker) error {
-	httpTimeOut := conn.config.HTTPTimeout
-
 	// new Transport
-	transport := &http.Transport{
-		Dial: func(netw, addr string) (net.Conn, error) {
-			conn, err := net.DialTimeout(netw, addr, httpTimeOut.ConnectTimeout)
-			if err != nil {
-				return nil, err
-			}
-			return newTimeoutConn(conn, httpTimeOut.ReadWriteTimeout, httpTimeOut.LongTimeout), nil
-		},
-		ResponseHeaderTimeout: httpTimeOut.HeaderTimeout,
-	}
+	transport := newTransport(conn, config)
 
 	// Proxy
 	if conn.config.IsUseProxy {

--- a/oss/transport_go16.go
+++ b/oss/transport_go16.go
@@ -1,0 +1,24 @@
+// +build !go1.7
+
+package oss
+
+import (
+	"net"
+	"net/http"
+)
+
+func newTransport(conn *Conn, config *Config) *http.Transport {
+	httpTimeOut := conn.config.HTTPTimeout
+	// new Transport
+	transport := &http.Transport{
+		Dial: func(netw, addr string) (net.Conn, error) {
+			conn, err := net.DialTimeout(netw, addr, httpTimeOut.ConnectTimeout)
+			if err != nil {
+				return nil, err
+			}
+			return newTimeoutConn(conn, httpTimeOut.ReadWriteTimeout, httpTimeOut.LongTimeout), nil
+		},
+		ResponseHeaderTimeout: httpTimeOut.HeaderTimeout,
+	}
+	return transport
+}

--- a/oss/transport_go17.go
+++ b/oss/transport_go17.go
@@ -1,0 +1,26 @@
+// go1.7 or later
+// +build go1.7
+
+package oss
+
+import (
+	"net"
+	"net/http"
+)
+
+func newTransport(conn *Conn, config *Config) *http.Transport {
+	httpTimeOut := conn.config.HTTPTimeout
+	// new Transport
+	transport := &http.Transport{
+		Dial: func(netw, addr string) (net.Conn, error) {
+			conn, err := net.DialTimeout(netw, addr, httpTimeOut.ConnectTimeout)
+			if err != nil {
+				return nil, err
+			}
+			return newTimeoutConn(conn, httpTimeOut.ReadWriteTimeout, httpTimeOut.LongTimeout), nil
+		},
+		IdleConnTimeout:       httpTimeOut.IdleConnTimeout,
+		ResponseHeaderTimeout: httpTimeOut.HeaderTimeout,
+	}
+	return transport
+}


### PR DESCRIPTION
Request may be failed if IdleConnTimeout is greater than
IdleConnTimeout of nginx before FIN received.

Close the idle connection before shutdown by nginx server.