### PR TITLE
修复连接池泄露的问题

### DIFF
--- a/oss/bucket.go
+++ b/oss/bucket.go
@@ -214,7 +214,7 @@ func (bucket Bucket) DoGetObject(request *GetObjectRequest, options []Option) (*
 	listener := getProgressListener(options)
 
 	contentLen, _ := strconv.ParseInt(resp.Headers.Get(HTTPHeaderContentLength), 10, 64)
-	resp.Body = ioutil.NopCloser(TeeReader(resp.Body, crcCalc, contentLen, listener, nil))
+	resp.Body = TeeReader(resp.Body, crcCalc, contentLen, listener, nil)
 
 	return result, nil
 }

--- a/oss/progress.go
+++ b/oss/progress.go
@@ -1,6 +1,8 @@
 package oss
 
-import "io"
+import (
+	"io"
+)
 
 // ProgressEventType transfer progress event type
 type ProgressEventType int
@@ -62,7 +64,7 @@ type teeReader struct {
 // corresponding writes to w.  There is no internal buffering -
 // the write must complete before the read completes.
 // Any error encountered while writing is reported as a read error.
-func TeeReader(reader io.Reader, writer io.Writer, totalBytes int64, listener ProgressListener, tracker *readerTracker) io.Reader {
+func TeeReader(reader io.Reader, writer io.Writer, totalBytes int64, listener ProgressListener, tracker *readerTracker) io.ReadCloser {
 	return &teeReader{
 		reader:        reader,
 		writer:        writer,
@@ -102,4 +104,11 @@ func (t *teeReader) Read(p []byte) (n int, err error) {
 	}
 
 	return
+}
+
+func (t *teeReader) Close() error {
+	if rc, ok := t.reader.(io.ReadCloser); ok {
+		return rc.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
由于 resp.Body 的 Close 方法被 ioutil.NopCloser 置空，当用户下载文件半途终止或者因为其它原因导致下载终止时，与 OSS 服务的链接无法被关闭，从而被堆积。

在我们的使用场景下，修复前，经常有上千的链接被堆积，TCP 内存消耗上 G。修复后，只有十几个并发的TCP 连接了。
