### PR TITLE
Update option.go

### DIFF
--- a/oss/option.go
+++ b/oss/option.go
@@ -280,7 +280,7 @@ func ResponseContentEncoding(value string) Option {
 
 // Process is an option to set X-Oss-Process param
 func Process(value string) Option {
-	return addParam("X-Oss-Process", value)
+	return addParam("x-oss-process", value)
 }
 func setHeader(key string, value interface{}) Option {
 	return func(params map[string]optionValue) error {


### PR DESCRIPTION
在调用该方法时，不能生成合适的option，
经过与帮助文档对比，发现将X-Oss-Process改为x-oss-process后，
生成的option作为参数执行bucket.SignUrl("objectKey","GET",400,option)，
可以生成合适的signUrl