### PR TITLE
<fix> Change process key word from "X-Oss-Process" to "x-oss-process"

### DIFF
--- a/oss/option.go
+++ b/oss/option.go
@@ -280,7 +280,7 @@ func ResponseContentEncoding(value string) Option {
 
 // Process is an option to set X-Oss-Process param
 func Process(value string) Option {
-	return addParam("X-Oss-Process", value)
+	return addParam("x-oss-process", value)
 }
 func setHeader(key string, value interface{}) Option {
 	return func(params map[string]optionValue) error {


### PR DESCRIPTION
今天发现阿里云的Process部分的key从X-Oss-Process改成了x-oss-process。如果还是用之前的，虽然不会报错，但是process的效果不会体现到图片上。