### PR TITLE
Only get userAgent when needed

### DIFF
--- a/oss/conf.go
+++ b/oss/conf.go
@@ -44,7 +44,7 @@ func getDefaultOssConfig() *Config {
 	config.AccessKeySecret = ""
 	config.RetryTimes = 5
 	config.IsDebug = false
-	config.UserAgent = userAgent
+	config.UserAgent = userAgent()
 	config.Timeout = 60  // Seconds
 	config.SecurityToken = ""
 	config.IsCname = false

--- a/oss/utils.go
+++ b/oss/utils.go
@@ -16,11 +16,11 @@ import (
 
 // userAgent gets user agent
 // It has the SDK version information, OS information and GO version
-var userAgent = func() string {
+func userAgent() string {
 	sys := getSysInfo()
 	return fmt.Sprintf("aliyun-sdk-go/%s (%s/%s/%s;%s)", Version, sys.name,
 		sys.release, sys.machine, runtime.Version())
-}()
+}
 
 type sysInfo struct {
 	name    string // OS name such as windows/Linux


### PR DESCRIPTION
The Go SDK is used by Hashicorp for Vault, and it retrieves information from the external environment on package initialization that won't necessarily be needed. This PR moves the call out of package initialization while retaining all normal functionality. 

See https://github.com/hashicorp/vault/issues/5324 for more.