### PR TITLE
not log http body on debug log level

### DIFF
--- a/oss/conn.go
+++ b/oss/conn.go
@@ -416,10 +416,10 @@ func (conn Conn) handleResponse(resp *http.Response, crc hash.Hash64) (*Response
 
 func (conn Conn) LoggerHttpReq(req *http.Request) {
 	var logBuffer bytes.Buffer
-	logBuffer.WriteString(fmt.Sprintf("[Req:%p]Method:%s,", req, req.Method))
-	logBuffer.WriteString(fmt.Sprintf("Host:%s,", req.URL.Host))
-	logBuffer.WriteString(fmt.Sprintf("Path:%s,", req.URL.Path))
-	logBuffer.WriteString(fmt.Sprintf("Query:%s,", req.URL.RawQuery))
+	logBuffer.WriteString(fmt.Sprintf("[Req:%p]Method:%s\t", req, req.Method))
+	logBuffer.WriteString(fmt.Sprintf("Host:%s\t", req.URL.Host))
+	logBuffer.WriteString(fmt.Sprintf("Path:%s\t", req.URL.Path))
+	logBuffer.WriteString(fmt.Sprintf("Query:%s\t", req.URL.RawQuery))
 	logBuffer.WriteString(fmt.Sprintf("Header info:"))
 
 	for k, v := range req.Header {
@@ -430,14 +430,14 @@ func (conn Conn) LoggerHttpReq(req *http.Request) {
 			}
 			valueBuffer.WriteString(v[j])
 		}
-		logBuffer.WriteString(fmt.Sprintf("%s:%s,", k, valueBuffer.String()))
+		logBuffer.WriteString(fmt.Sprintf("\t%s:%s", k, valueBuffer.String()))
 	}
-	conn.config.WriteLog(Debug, "%s.\n", logBuffer.String())
+	conn.config.WriteLog(Debug, "%s\n", logBuffer.String())
 }
 
 func (conn Conn) LoggerHttpResp(req *http.Request, resp *http.Response) {
 	var logBuffer bytes.Buffer
-	logBuffer.WriteString(fmt.Sprintf("[Resp:%p]StatusCode:%d,", req, resp.StatusCode))
+	logBuffer.WriteString(fmt.Sprintf("[Resp:%p]StatusCode:%d\t", req, resp.StatusCode))
 	logBuffer.WriteString(fmt.Sprintf("Header info:"))
 	for k, v := range resp.Header {
 		var valueBuffer bytes.Buffer
@@ -447,28 +447,9 @@ func (conn Conn) LoggerHttpResp(req *http.Request, resp *http.Response) {
 			}
 			valueBuffer.WriteString(v[j])
 		}
-		logBuffer.WriteString(fmt.Sprintf("%s:%s,", k, valueBuffer.String()))
+		logBuffer.WriteString(fmt.Sprintf("\t%s:%s", k, valueBuffer.String()))
 	}
-
-	statusCode := resp.StatusCode
-	if statusCode >= 400 && statusCode <= 505 {
-		// 4xx and 5xx indicate that the operation has error occurred
-		var respBody []byte
-		respBody, err := readResponseBody(resp)
-		if err != nil {
-			return
-		}
-
-		if len(respBody) == 0 {
-			// No error in response body
-		} else {
-			// Response contains storage service error object, unmarshal
-			logBuffer.WriteString(fmt.Sprintf("Body:%s", string(respBody)))
-		}
-	} else if statusCode >= 300 && statusCode <= 307 {
-		// OSS use 3xx, but response has no body
-	}
-	conn.config.WriteLog(Debug, "%s.\n", logBuffer.String())
+	conn.config.WriteLog(Debug, "%s\n", logBuffer.String())
 }
 
 func calcMD5(body io.Reader, contentLen, md5Threshold int64) (reader io.Reader, b64 string, tempFile *os.File, err error) {


### PR DESCRIPTION
1、because func readResponseBody will close the resp.Body，we can't call readResponseBody in func LoggerHttpResp