### PR TITLE
fix func TestListMultipartUploads:  expected and obtained is  inconsistent

### DIFF
--- a/oss/bucket_test.go
+++ b/oss/bucket_test.go
@@ -46,7 +46,7 @@ func (s *OssBucketSuite) SetUpSuite(c *C) {
 	err = s.client.CreateBucket(archiveBucketName, StorageClass(StorageArchive))
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	// time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)
@@ -587,7 +587,7 @@ func (s *OssBucketSuite) TestPutObjectType(c *C) {
 	c.Assert(err, IsNil)
 
 	// Check
-	time.Sleep(time.Second)
+	// time.Sleep(timeoutInOperation)
 	body, err := s.bucket.GetObject(objectName)
 	c.Assert(err, IsNil)
 	str, err := readBody(body)

--- a/oss/client_test.go
+++ b/oss/client_test.go
@@ -54,10 +54,11 @@ const (
 )
 
 var (
-	logPath        = "go_sdk_test_" + time.Now().Format("20060102_150405") + ".log"
-	testLogFile, _ = os.OpenFile(logPath, os.O_RDWR|os.O_CREATE, 0664)
-	testLogger     = log.New(testLogFile, "", log.Ldate|log.Ltime|log.Lshortfile)
-	letters        = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	logPath            = "go_sdk_test_" + time.Now().Format("20060102_150405") + ".log"
+	testLogFile, _     = os.OpenFile(logPath, os.O_RDWR|os.O_CREATE, 0664)
+	testLogger         = log.New(testLogFile, "", log.Ldate|log.Ltime|log.Lshortfile)
+	letters            = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	timeoutInOperation = 3 * time.Second
 )
 
 func randStr(n int) string {
@@ -160,7 +161,7 @@ func (s *OssClientSuite) TestCreateBucket(c *C) {
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
 	//sleep 5 seconds after create bucket
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// verify bucket is exist
 	found, err := client.IsBucketExist(bucketNameTest)
@@ -173,12 +174,12 @@ func (s *OssClientSuite) TestCreateBucket(c *C) {
 
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// CreateBucket creates with ACLPublicRead
 	err = client.CreateBucket(bucketNameTest, ACL(ACLPublicRead))
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -186,11 +187,12 @@ func (s *OssClientSuite) TestCreateBucket(c *C) {
 
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// ACLPublicReadWrite
 	err = client.CreateBucket(bucketNameTest, ACL(ACLPublicReadWrite))
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -198,11 +200,12 @@ func (s *OssClientSuite) TestCreateBucket(c *C) {
 
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// ACLPrivate
 	err = client.CreateBucket(bucketNameTest, ACL(ACLPrivate))
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -217,6 +220,7 @@ func (s *OssClientSuite) TestCreateBucket(c *C) {
 		bucketNameTest := bucketNamePrefix + randLowStr(5)
 		err = client.CreateBucket(bucketNameTest, StorageClass(storage), ACL(ACLPublicRead))
 		c.Assert(err, IsNil)
+		time.Sleep(timeoutInOperation)
 
 		res, err := client.GetBucketInfo(bucketNameTest)
 		c.Assert(err, IsNil)
@@ -238,6 +242,7 @@ func (s *OssClientSuite) TestCreateBucket(c *C) {
 		bucketNameTest := bucketNamePrefix + randLowStr(5)
 		err = client.CreateBucket(bucketNameTest, StorageClass(storage))
 		c.Assert(err, IsNil)
+		time.Sleep(timeoutInOperation)
 
 		res, err := client.GetBucketInfo(bucketNameTest)
 		c.Assert(err, IsNil)
@@ -283,7 +288,7 @@ func (s *OssClientSuite) TestDeleteBucket(c *C) {
 	// Create
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// Check
 	found, err := client.IsBucketExist(bucketNameTest)
@@ -293,7 +298,7 @@ func (s *OssClientSuite) TestDeleteBucket(c *C) {
 	// Delete
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(3 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// Check
 	found, err = client.IsBucketExist(bucketNameTest)
@@ -457,7 +462,7 @@ func (s *OssClientSuite) TestSetBucketAcl(c *C) {
 	// Set ACL_PUBLIC_R
 	err = client.SetBucketACL(bucketNameTest, ACLPublicRead)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -466,7 +471,7 @@ func (s *OssClientSuite) TestSetBucketAcl(c *C) {
 	// Set ACL_PUBLIC_RW
 	err = client.SetBucketACL(bucketNameTest, ACLPublicReadWrite)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -477,7 +482,7 @@ func (s *OssClientSuite) TestSetBucketAcl(c *C) {
 	c.Assert(err, IsNil)
 	err = client.SetBucketACL(bucketNameTest, ACLPrivate)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -515,6 +520,7 @@ func (s *OssClientSuite) TestGetBucketAcl(c *C) {
 	// Private
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	res, err := client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -522,12 +528,12 @@ func (s *OssClientSuite) TestGetBucketAcl(c *C) {
 
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// PublicRead
 	err = client.CreateBucket(bucketNameTest, ACL(ACLPublicRead))
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -535,12 +541,12 @@ func (s *OssClientSuite) TestGetBucketAcl(c *C) {
 
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// PublicReadWrite
 	err = client.CreateBucket(bucketNameTest, ACL(ACLPublicReadWrite))
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -595,6 +601,7 @@ func (s *OssClientSuite) TestSetBucketLifecycle(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	// Set single rule
 	var rules = []LifecycleRule{rule1}
@@ -618,7 +625,7 @@ func (s *OssClientSuite) TestSetBucketLifecycle(c *C) {
 	c.Assert(err, IsNil)
 
 	// Eliminate effect of cache
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketLifecycle(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -643,13 +650,14 @@ func (s *OssClientSuite) TestDeleteBucketLifecycle(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	err = client.DeleteBucketLifecycle(bucketNameTest)
 	c.Assert(err, IsNil)
 
 	err = client.SetBucketLifecycle(bucketNameTest, rules)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err := client.GetBucketLifecycle(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -659,12 +667,12 @@ func (s *OssClientSuite) TestDeleteBucketLifecycle(c *C) {
 	err = client.DeleteBucketLifecycle(bucketNameTest)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketLifecycle(bucketNameTest)
 	c.Assert(err, NotNil)
 
 	// Eliminate effect of cache
-	time.Sleep(time.Second * 3)
+	time.Sleep(timeoutInOperation)
 
 	// Delete when not set
 	err = client.DeleteBucketLifecycle(bucketNameTest)
@@ -715,6 +723,7 @@ func (s *OssClientSuite) TestSetBucketReferer(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	res, err := client.GetBucketReferer(bucketNameTest)
 	c.Assert(res.AllowEmptyReferer, Equals, true)
@@ -723,7 +732,7 @@ func (s *OssClientSuite) TestSetBucketReferer(c *C) {
 	// Set referers
 	err = client.SetBucketReferer(bucketNameTest, referers, false)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketReferer(bucketNameTest)
 	c.Assert(res.AllowEmptyReferer, Equals, false)
@@ -779,7 +788,7 @@ func (s *OssClientSuite) TestSetBucketLogging(c *C) {
 	c.Assert(err, IsNil)
 	err = client.CreateBucket(bucketNameTarget)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// Set logging
 	err = client.SetBucketLogging(bucketNameTest, bucketNameTarget, "prefix", true)
@@ -788,7 +797,7 @@ func (s *OssClientSuite) TestSetBucketLogging(c *C) {
 	err = client.SetBucketLogging(bucketNameTest, bucketNameTarget, "prefix", false)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err := client.GetBucketLogging(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.LoggingEnabled.TargetBucket, Equals, "")
@@ -819,6 +828,7 @@ func (s *OssClientSuite) TestDeleteBucketLogging(c *C) {
 	c.Assert(err, IsNil)
 	err = client.CreateBucket(bucketNameTarget)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	// Get when not set
 	res, err := client.GetBucketLogging(bucketNameTest)
@@ -831,7 +841,7 @@ func (s *OssClientSuite) TestDeleteBucketLogging(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketLogging(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.LoggingEnabled.TargetBucket, Equals, bucketNameTarget)
@@ -842,7 +852,7 @@ func (s *OssClientSuite) TestDeleteBucketLogging(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketLogging(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.LoggingEnabled.TargetBucket, Equals, "")
@@ -853,7 +863,7 @@ func (s *OssClientSuite) TestDeleteBucketLogging(c *C) {
 	c.Assert(err, IsNil)
 
 	// Get after delete
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketLogging(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.LoggingEnabled.TargetBucket, Equals, "")
@@ -887,7 +897,7 @@ func (s *OssClientSuite) TestSetBucketLoggingNegative(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// Target bucket not exist
 	err = client.SetBucketLogging(bucketNameTest, bucketNameTarget, "prefix", true)
@@ -912,6 +922,7 @@ func (s *OssClientSuite) TestSetBucketWebsite(c *C) {
 
 	client, err := New(endpoint, accessID, accessKey)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -933,7 +944,7 @@ func (s *OssClientSuite) TestSetBucketWebsite(c *C) {
 	err = client.SetBucketWebsite(bucketNameTest, "your"+indexWebsite, "your"+errorWebsite)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketWebsite(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.IndexDocument.Suffix, Equals, "your"+indexWebsite)
@@ -947,7 +958,7 @@ func (s *OssClientSuite) TestSetBucketWebsite(c *C) {
 	c.Assert(err, IsNil)
 
 	// Eliminate effect of cache
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	res, err = client.GetBucketWebsite(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -969,6 +980,7 @@ func (s *OssClientSuite) TestDeleteBucketWebsite(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	// Get
 	res, err := client.GetBucketWebsite(bucketNameTest)
@@ -982,18 +994,18 @@ func (s *OssClientSuite) TestDeleteBucketWebsite(c *C) {
 	err = client.SetBucketWebsite(bucketNameTest, indexWebsite, errorWebsite)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketWebsite(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.IndexDocument.Suffix, Equals, indexWebsite)
 	c.Assert(res.ErrorDocument.Key, Equals, errorWebsite)
 
 	// Detele
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	err = client.DeleteBucketWebsite(bucketNameTest)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketWebsite(bucketNameTest)
 	c.Assert(err, NotNil)
 
@@ -1030,7 +1042,7 @@ func (s *OssClientSuite) TestSetBucketWebsiteNegative(c *C) {
 	c.Assert(err, IsNil)
 
 	// Set
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	err = client.SetBucketWebsite(bucketNameTest, "myindex", "myerror")
 	c.Assert(err, IsNil)
 
@@ -1043,7 +1055,7 @@ func (s *OssClientSuite) TestSetBucketWebsiteNegative(c *C) {
 	err = client.DeleteBucketWebsite(bucketNameTest)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	_, err = client.GetBucketWebsite(bucketNameTest)
 	c.Assert(err, NotNil)
 
@@ -1079,7 +1091,7 @@ func (s *OssClientSuite) TestSetBucketCORS(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// Set
 	err = client.SetBucketCORS(bucketNameTest, []CORSRule{rule1})
@@ -1111,7 +1123,7 @@ func (s *OssClientSuite) TestSetBucketCORS(c *C) {
 	err = client.SetBucketCORS(bucketNameTest, []CORSRule{rule2})
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	gbcr, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(len(gbcr.CORSRules), Equals, 1)
@@ -1125,7 +1137,7 @@ func (s *OssClientSuite) TestSetBucketCORS(c *C) {
 	err = client.SetBucketCORS(bucketNameTest, []CORSRule{rule1, rule2})
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	gbcr, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(len(gbcr.CORSRules), Equals, 2)
@@ -1137,7 +1149,7 @@ func (s *OssClientSuite) TestSetBucketCORS(c *C) {
 	err = client.SetBucketCORS(bucketNameTest, []CORSRule{rule1, rule2})
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	gbcr, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(len(gbcr.CORSRules), Equals, 2)
@@ -1165,6 +1177,7 @@ func (s *OssClientSuite) TestDeleteBucketCORS(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	// Delete not set
 	err = client.DeleteBucketCORS(bucketNameTest)
@@ -1174,7 +1187,7 @@ func (s *OssClientSuite) TestDeleteBucketCORS(c *C) {
 	err = client.SetBucketCORS(bucketNameTest, []CORSRule{rule})
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	_, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
 
@@ -1182,7 +1195,7 @@ func (s *OssClientSuite) TestDeleteBucketCORS(c *C) {
 	err = client.DeleteBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	_, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, NotNil)
 
@@ -1222,7 +1235,7 @@ func (s *OssClientSuite) TestSetBucketCORSNegative(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	_, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, NotNil)
@@ -1230,7 +1243,7 @@ func (s *OssClientSuite) TestSetBucketCORSNegative(c *C) {
 	// Set
 	err = client.SetBucketCORS(bucketNameTest, []CORSRule{rule})
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	_, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -1239,7 +1252,7 @@ func (s *OssClientSuite) TestSetBucketCORSNegative(c *C) {
 	err = client.DeleteBucketCORS(bucketNameTest)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	_, err = client.GetBucketCORS(bucketNameTest)
 	c.Assert(err, NotNil)
 
@@ -1300,6 +1313,7 @@ func (s *OssClientSuite) TestEndpointFormat(c *C) {
 
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
+	time.Sleep(timeoutInOperation)
 
 	res, err := client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
@@ -1307,7 +1321,7 @@ func (s *OssClientSuite) TestEndpointFormat(c *C) {
 
 	err = client.DeleteBucket(bucketNameTest)
 	c.Assert(err, IsNil)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	// http://host:port
 	client, err = New(endpoint+":80", accessID, accessKey)
@@ -1316,7 +1330,7 @@ func (s *OssClientSuite) TestEndpointFormat(c *C) {
 	err = client.CreateBucket(bucketNameTest)
 	c.Assert(err, IsNil)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 	res, err = client.GetBucketACL(bucketNameTest)
 	c.Assert(err, IsNil)
 	c.Assert(res.ACL, Equals, string(ACLPrivate))

--- a/oss/crc_test.go
+++ b/oss/crc_test.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"os"
 	"strings"
-	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -28,7 +27,7 @@ func (s *OssCrcSuite) SetUpSuite(c *C) {
 	s.client = client
 
 	s.client.CreateBucket(bucketName)
-	time.Sleep(5 * time.Second)
+	// time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)

--- a/oss/download_test.go
+++ b/oss/download_test.go
@@ -23,7 +23,7 @@ func (s *OssDownloadSuite) SetUpSuite(c *C) {
 	s.client = client
 
 	s.client.CreateBucket(bucketName)
-	time.Sleep(5 * time.Second)
+	// time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)

--- a/oss/multicopy_test.go
+++ b/oss/multicopy_test.go
@@ -22,7 +22,7 @@ func (s *OssCopySuite) SetUpSuite(c *C) {
 	s.client = client
 
 	s.client.CreateBucket(bucketName)
-	time.Sleep(5 * time.Second)
+	// time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)

--- a/oss/multipart_test.go
+++ b/oss/multipart_test.go
@@ -26,7 +26,7 @@ func (s *OssBucketMultipartSuite) SetUpSuite(c *C) {
 	s.client = client
 
 	s.client.CreateBucket(bucketName)
-	time.Sleep(5 * time.Second)
+	time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)

--- a/oss/multipart_test.go
+++ b/oss/multipart_test.go
@@ -568,12 +568,12 @@ func (s *OssBucketMultipartSuite) TestListMultipartUploads(c *C) {
 	c.Assert(len(lmpu.Uploads), Equals, 18)
 	c.Assert(len(lmpu.CommonPrefixes), Equals, 2)
 
-	// Upload-id-marker
-	lmpu, err = s.bucket.ListMultipartUploads(KeyMarker(objectName+"12"), UploadIDMarker("EEE"))
+	upLoadIDStr := randStr(3)
+	lmpu, err = s.bucket.ListMultipartUploads(KeyMarker(objectName+"12"), UploadIDMarker(upLoadIDStr))
 	c.Assert(err, IsNil)
 	checkNum := 15
 	for _, im := range imurs {
-		if im.Key == objectName+"12" && im.UploadID > "EEE" {
+		if im.Key == objectName+"12" && im.UploadID > "upLoadIDStr" {
 			checkNum = 16
 			break
 		}

--- a/oss/multipart_test.go
+++ b/oss/multipart_test.go
@@ -571,7 +571,14 @@ func (s *OssBucketMultipartSuite) TestListMultipartUploads(c *C) {
 	// Upload-id-marker
 	lmpu, err = s.bucket.ListMultipartUploads(KeyMarker(objectName+"12"), UploadIDMarker("EEE"))
 	c.Assert(err, IsNil)
-	c.Assert(len(lmpu.Uploads), Equals, 15)
+	checkNum := 15
+	for _, im := range imurs {
+		if im.Key == objectName+"12" && im.UploadID > "EEE" {
+			checkNum = 16
+			break
+		}
+	}
+	c.Assert(len(lmpu.Uploads), Equals, checkNum)
 	//testLogger.Println("UploadIDMarker", lmpu.Uploads)
 
 	for _, imur := range imurs {

--- a/oss/progress_test.go
+++ b/oss/progress_test.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"os"
 	"strings"
-	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -27,7 +26,7 @@ func (s *OssProgressSuite) SetUpSuite(c *C) {
 	s.client = client
 
 	s.client.CreateBucket(bucketName)
-	time.Sleep(5 * time.Second)
+	// time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)

--- a/oss/upload_test.go
+++ b/oss/upload_test.go
@@ -23,7 +23,7 @@ func (s *OssUploadSuite) SetUpSuite(c *C) {
 	s.client = client
 
 	s.client.CreateBucket(bucketName)
-	time.Sleep(5 * time.Second)
+	// time.Sleep(timeoutInOperation)
 
 	bucket, err := s.client.Bucket(bucketName)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
fix func TestListMultipartUploads: When both "key-marker" and "upload-id-marker" parameters exist  at the same time，return Objects which name >= "key-marker"  value.