### PR TITLE
add range case in the GetObjectSample function

### DIFF
--- a/sample/get_object.go
+++ b/sample/get_object.go
@@ -37,7 +37,16 @@ func GetObjectSample() {
 	}
 	fmt.Println("size of data is: ", len(data))
 
-	// Case 2: Download the object to byte array. This is for small object.
+	// Case 2: Download in the range of object.
+	body, err = bucket.GetObject(objectKey, oss.Range(15, 19))
+	if err != nil {
+		HandleError(err)
+	}
+	data, err = ioutil.ReadAll(body)
+	body.Close()
+	fmt.Println("the range of data is: ", string(data))
+
+	// Case 3: Download the object to byte array. This is for small object.
 	buf := new(bytes.Buffer)
 	body, err = bucket.GetObject(objectKey)
 	if err != nil {
@@ -46,7 +55,7 @@ func GetObjectSample() {
 	io.Copy(buf, body)
 	body.Close()
 
-	// Case 3: Download the object to local file. The file handle needs to be specified
+	// Case 4: Download the object to local file. The file handle needs to be specified
 	fd, err := os.OpenFile("mynewfile-1.jpg", os.O_WRONLY|os.O_CREATE, 0660)
 	if err != nil {
 		HandleError(err)
@@ -60,13 +69,13 @@ func GetObjectSample() {
 	io.Copy(fd, body)
 	body.Close()
 
-	// Case 4: Download the object to local file with file name specified
+	// Case 5: Download the object to local file with file name specified
 	err = bucket.GetObjectToFile(objectKey, "mynewfile-2.jpg")
 	if err != nil {
 		HandleError(err)
 	}
 
-	// Case 5: Get the object with contraints. When contraints are met, download the file. Otherwise return precondition error
+	// Case 6: Get the object with contraints. When contraints are met, download the file. Otherwise return precondition error
 	// last modified time constraint is met, download the file
 	body, err = bucket.GetObject(objectKey, oss.IfModifiedSince(pastDate))
 	if err != nil {
@@ -75,11 +84,11 @@ func GetObjectSample() {
 	body.Close()
 
 	// Last modified time contraint is not met, do not download the file
-	body, err = bucket.GetObject(objectKey, oss.IfUnmodifiedSince(pastDate))
+	_, err = bucket.GetObject(objectKey, oss.IfUnmodifiedSince(pastDate))
 	if err == nil {
 		HandleError(err)
 	}
-	body.Close()
+	// body.Close()
 
 	meta, err := bucket.GetObjectDetailedMeta(objectKey)
 	if err != nil {
@@ -94,13 +103,13 @@ func GetObjectSample() {
 	body.Close()
 
 	// Check the content, etag contraint is not met, do not download the file
-	body, err = bucket.GetObject(objectKey, oss.IfNoneMatch(etag))
+	_, err = bucket.GetObject(objectKey, oss.IfNoneMatch(etag))
 	if err == nil {
 		HandleError(err)
 	}
-	body.Close()
+	// body.Close()
 
-	// Case 6: Big file's multipart download, concurrent and resumable download is supported.
+	// Case 7: Big file's multipart download, concurrent and resumable download is supported.
 	// multipart download with part size 100KB. By default single coroutine is used and no checkpoint
 	err = bucket.DownloadFile(objectKey, "mynewfile-3.jpg", 100*1024)
 	if err != nil {
@@ -126,7 +135,7 @@ func GetObjectSample() {
 		HandleError(err)
 	}
 
-	// Case 7: Use GZIP encoding for downloading the file, GetObject/GetObjectToFile are the same.
+	// Case 8: Use GZIP encoding for downloading the file, GetObject/GetObjectToFile are the same.
 	err = bucket.PutObjectFromFile(objectKey, htmlLocalFile)
 	if err != nil {
 		HandleError(err)


### PR DESCRIPTION
1、The "body.Close()" execution failed, when "body" is "nil"
2、add range case.