### PR TITLE
feat: update WebsiteXML

### DIFF
--- a/oss/type.go
+++ b/oss/type.go
@@ -199,8 +199,10 @@ type WebsiteXML struct {
 
 // IndexDocument defines the index page info
 type IndexDocument struct {
-	XMLName xml.Name `xml:"IndexDocument"`
-	Suffix  string   `xml:"Suffix"` // The file name for the index page
+	XMLName       xml.Name `xml:"IndexDocument"`
+	Suffix        string   `xml:"Suffix"`        // The file name for the index page
+	SupportSubDir *bool    `xml:"SupportSubDir"` // Specifies whether to search for the default homepage of a subfolder when you access the subfolder.
+	Type          *int     `xml:"Type"`          // The operation type when the default homepage of a subfolder doesn't exist, it has 0, 1, 2
 }
 
 // ErrorDocument defines the 404 error page info
@@ -221,7 +223,8 @@ type RoutingRule struct {
 // Condition defines codition in the RoutingRule
 type Condition struct {
 	XMLName                     xml.Name        `xml:"Condition"`
-	KeyPrefixEquals             string          `xml:"KeyPrefixEquals,omitempty"`             // Matching objcet prefix
+	KeyPrefixEquals             string          `xml:"KeyPrefixEquals,omitempty"`             // Matching object prefix
+	KeySuffixEquals             string          `xml:"KeySuffixEquals,omitempty"`             // Matching object suffix
 	HTTPErrorCodeReturnedEquals int             `xml:"HttpErrorCodeReturnedEquals,omitempty"` // The rule is for Accessing to the specified object
 	IncludeHeader               []IncludeHeader `xml:"IncludeHeader"`                         // The rule is for request which include header
 }


### PR DESCRIPTION
According to [document](https://help.aliyun.com/document_detail/31962.html?spm=a2c4g.11186623.2.11.6985300ee1gg6v#reference-hwb-yr5-tdb)
add 'SupportSubDir', 'Type' to 'IndexDocument'.
add 'KeySuffixEquals' to 'Condition'

The document also contains new config `EnableReplacePrefix`. It seems it is not very necessary, so it is not included in this commit.

## base
```go
	wxml := oss.WebsiteXML{}
	wxml.IndexDocument.Suffix = "index.html"
	wxml.ErrorDocument.Key = "404.html"

	output, _ := xml.MarshalIndent(wxml, "  ", "    ")
	fmt.Printf("%s\n", output)
```
**output**
```xml
  <WebsiteConfiguration>
      <IndexDocument>
          <Suffix>index.html</Suffix>
      </IndexDocument>
      <ErrorDocument>
          <Key>404.html</Key>
      </ErrorDocument>
      <RoutingRules></RoutingRules>
  </WebsiteConfiguration>
```
## set `SupportSubDir`, `Type`
```go
	bEnable := true
	supportSubDirType := 0
	wxml := oss.WebsiteXML{}
	wxml.IndexDocument.Suffix = "index.html"
	wxml.ErrorDocument.Key = "404.html"
	wxml.IndexDocument.SupportSubDir = &bEnable
	wxml.IndexDocument.Type = &supportSubDirType

	output, _ := xml.MarshalIndent(wxml, "  ", "    ")
	fmt.Printf("%s\n", output)
```

**output**
```xml
  <WebsiteConfiguration>
      <IndexDocument>
          <Suffix>index.html</Suffix>
          <SupportSubDir>true</SupportSubDir>
          <Type>0</Type>
      </IndexDocument>
      <ErrorDocument>
          <Key>404.html</Key>
      </ErrorDocument>
      <RoutingRules></RoutingRules>
  </WebsiteConfiguration>
```
