### PR TITLE
adding subfolder homepage types to IndexDocument

### DIFF
--- a/oss/type.go
+++ b/oss/type.go
@@ -199,8 +199,10 @@ type WebsiteXML struct {
 
 // IndexDocument defines the index page info
 type IndexDocument struct {
-	XMLName xml.Name `xml:"IndexDocument"`
-	Suffix  string   `xml:"Suffix"` // The file name for the index page
+	XMLName       xml.Name `xml:"IndexDocument"`
+	Suffix        string   `xml:"Suffix"`        // The file name for the index page
+	SupportSubDir bool     `xml:"SupportSubDir"` // whether or not subfolder homepage is enabled
+	Type          int      `xml:"Type"`          // the subfolder homepage behavior. 0 means Redirect, 1 means NoSuchKey, 2 means Index
 }
 
 // ErrorDocument defines the 404 error page info


### PR DESCRIPTION
This PR adds in the API options necessary to enable and configure the Subfolder Homepage options for static websites on OSS. These options don't seem to be documented anywhere in the API docs, but you can see the options in the Alicloud OSS UI, and if you look at the XML responses from the API you'll see they exist. I had to reverse-engineer how this works; This should be added to the API docs.

<img width="429" alt="Screen Shot 2020-11-13 at 11 37 49" src="https://user-images.githubusercontent.com/200725/99068640-c7177680-25a4-11eb-9654-59f3a7d8b28f.png">
<img width="245" alt="Screen Shot 2020-11-13 at 11 38 55" src="https://user-images.githubusercontent.com/200725/99068660-d39bcf00-25a4-11eb-86ef-c7ffb136a18e.png">

Without adding these options, every time `SetBucketWebsiteDetail` is called it just deletes the subfolder homepage settings on the OSS bucket. 
