### PR TITLE
过滤DeleteObject的参数

### DIFF
--- a/oss/bucket.go
+++ b/oss/bucket.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"hash"
 	"hash/crc64"
@@ -421,6 +422,9 @@ func (bucket Bucket) DoAppendObject(request *AppendObjectRequest, options []Opti
 // error    it's nil if no error, otherwise it's an error object.
 //
 func (bucket Bucket) DeleteObject(objectKey string, options ...Option) error {
+	if objectKey == "" {
+		return errors.New("objectKey cannot be empty")
+	}
 	params, _ := GetRawParams(options)
 	resp, err := bucket.do("DELETE", objectKey, params, options, nil, nil)
 	if err != nil {


### PR DESCRIPTION
过滤DeleteObject的参数，如果不过滤，当objectKey为空，并且bucket内没有其他object时，调用DelectObject会直接删掉bucket。