### PR TITLE
[enhancement] Add maxconnsperhost for oss HTTP transport

### DIFF
--- a/oss/bucket_test.go
+++ b/oss/bucket_test.go
@@ -2043,8 +2043,7 @@ func (s *OssBucketSuite) TestAddContentType(c *C) {
 
 func (s *OssBucketSuite) TestGetConfig(c *C) {
 	client, err := New(endpoint, accessID, accessKey, UseCname(true),
-		Timeout(11, 12), SecurityToken("token"), EnableMD5(false),
-		MaxConns(10, 10, 100))
+		Timeout(11, 12), SecurityToken("token"), EnableMD5(false))
 	c.Assert(err, IsNil)
 
 	bucket, err := client.Bucket(bucketName)
@@ -2055,10 +2054,6 @@ func (s *OssBucketSuite) TestGetConfig(c *C) {
 	c.Assert(bucket.GetConfig().HTTPTimeout.HeaderTimeout, Equals, time.Second*12)
 	c.Assert(bucket.GetConfig().HTTPTimeout.IdleConnTimeout, Equals, time.Second*12)
 	c.Assert(bucket.GetConfig().HTTPTimeout.LongTimeout, Equals, time.Second*12*10)
-
-	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxIdleConns, Equals, 10)
-	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxIdleConnsPerHost, Equals, 10)
-	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxConnsPerHost, Equals, 100)
 
 	c.Assert(bucket.GetConfig().SecurityToken, Equals, "token")
 	c.Assert(bucket.GetConfig().IsCname, Equals, true)

--- a/oss/bucket_test.go
+++ b/oss/bucket_test.go
@@ -2043,7 +2043,8 @@ func (s *OssBucketSuite) TestAddContentType(c *C) {
 
 func (s *OssBucketSuite) TestGetConfig(c *C) {
 	client, err := New(endpoint, accessID, accessKey, UseCname(true),
-		Timeout(11, 12), SecurityToken("token"), EnableMD5(false))
+		Timeout(11, 12), SecurityToken("token"), EnableMD5(false),
+		MaxConns(10, 10, 100))
 	c.Assert(err, IsNil)
 
 	bucket, err := client.Bucket(bucketName)
@@ -2054,6 +2055,10 @@ func (s *OssBucketSuite) TestGetConfig(c *C) {
 	c.Assert(bucket.GetConfig().HTTPTimeout.HeaderTimeout, Equals, time.Second*12)
 	c.Assert(bucket.GetConfig().HTTPTimeout.IdleConnTimeout, Equals, time.Second*12)
 	c.Assert(bucket.GetConfig().HTTPTimeout.LongTimeout, Equals, time.Second*12*10)
+
+	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxIdleConns, Equals, 10)
+	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxIdleConnsPerHost, Equals, 10)
+	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxConnsPerHost, Equals, 100)
 
 	c.Assert(bucket.GetConfig().SecurityToken, Equals, "token")
 	c.Assert(bucket.GetConfig().IsCname, Equals, true)

--- a/oss/client.go
+++ b/oss/client.go
@@ -1868,6 +1868,20 @@ func Timeout(connectTimeoutSec, readWriteTimeout int64) ClientOption {
 	}
 }
 
+// MaxConns sets the HTTP max connections for a client.
+//
+// maxIdleConns    controls the maximum number of idle (keep-alive) connections across all hosts. Default is 100.
+// maxIdleConnsPerHost    controls the maximum idle (keep-alive) connections to keep per-host. Default is 100.
+// maxConnsPerHost    limits the total number of connections per host. Default is no limit.
+//
+func MaxConns(maxIdleConns, maxIdleConnsPerHost, maxConnsPerHost int) ClientOption {
+	return func(client *Client) {
+		client.Config.HTTPMaxConns.MaxIdleConns = maxIdleConns
+		client.Config.HTTPMaxConns.MaxIdleConnsPerHost = maxIdleConnsPerHost
+		client.Config.HTTPMaxConns.MaxConnsPerHost = maxConnsPerHost
+	}
+}
+
 // SecurityToken sets the temporary user's SecurityToken.
 //
 // token    STS token

--- a/oss/client_test.go
+++ b/oss/client_test.go
@@ -2880,6 +2880,34 @@ func (s *OssClientSuite) TestBucketEncyptionPutObjectError(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *OssClientSuite) TestMaxConnsPutObjectSuccess(c *C) {
+	client, err := New(endpoint, accessID, accessKey)
+	c.Assert(err, IsNil)
+
+	bucketName := bucketNamePrefix + RandLowStr(5)
+	err = client.CreateBucket(bucketName)
+	c.Assert(err, IsNil)
+
+	bucket, err := client.Bucket(bucketName)
+	c.Assert(err, IsNil)
+
+	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxIdleConns, Equals, 100)
+	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxIdleConnsPerHost, Equals, 100)
+	c.Assert(bucket.GetConfig().HTTPMaxConns.MaxConnsPerHost, Equals, 0)
+
+	// put object
+	objectName := objectNamePrefix + RandLowStr(5)
+	err = bucket.PutObject(objectName, strings.NewReader(RandStr(10)))
+	c.Assert(err, IsNil)
+
+	bucket.DeleteObject(objectName)
+	err = bucket.PutObject(objectName, strings.NewReader(RandStr(10)))
+	c.Assert(err, IsNil)
+	bucket.DeleteObject(objectName)
+
+	client.DeleteBucket(bucketName)
+}
+
 func (s *OssClientSuite) TestBucketTaggingOperation(c *C) {
 	client, err := New(endpoint, accessID, accessKey)
 	c.Assert(err, IsNil)

--- a/oss/conf.go
+++ b/oss/conf.go
@@ -34,6 +34,7 @@ type HTTPTimeout struct {
 type HTTPMaxConns struct {
 	MaxIdleConns        int
 	MaxIdleConnsPerHost int
+	MaxConnsPerHost     int
 }
 
 // CredentialInf is interface for get AccessKeyID,AccessKeySecret,SecurityToken
@@ -182,6 +183,7 @@ func getDefaultOssConfig() *Config {
 	config.HTTPTimeout.IdleConnTimeout = time.Second * 50  // 50s
 	config.HTTPMaxConns.MaxIdleConns = 100
 	config.HTTPMaxConns.MaxIdleConnsPerHost = 100
+	config.HTTPMaxConns.MaxConnsPerHost = 0
 
 	config.IsUseProxy = false
 	config.ProxyHost = ""

--- a/oss/conf.go
+++ b/oss/conf.go
@@ -183,7 +183,6 @@ func getDefaultOssConfig() *Config {
 	config.HTTPTimeout.IdleConnTimeout = time.Second * 50  // 50s
 	config.HTTPMaxConns.MaxIdleConns = 100
 	config.HTTPMaxConns.MaxIdleConnsPerHost = 100
-	config.HTTPMaxConns.MaxConnsPerHost = 0
 
 	config.IsUseProxy = false
 	config.ProxyHost = ""

--- a/oss/transport_1_7.go
+++ b/oss/transport_1_7.go
@@ -32,6 +32,7 @@ func newTransport(conn *Conn, config *Config) *http.Transport {
 		MaxIdleConnsPerHost:   httpMaxConns.MaxIdleConnsPerHost,
 		IdleConnTimeout:       httpTimeOut.IdleConnTimeout,
 		ResponseHeaderTimeout: httpTimeOut.HeaderTimeout,
+		MaxConnsPerHost:       httpMaxConns.MaxConnsPerHost,
 	}
 
 	if config.InsecureSkipVerify {

--- a/oss/transport_1_7.go
+++ b/oss/transport_1_7.go
@@ -30,9 +30,9 @@ func newTransport(conn *Conn, config *Config) *http.Transport {
 		},
 		MaxIdleConns:          httpMaxConns.MaxIdleConns,
 		MaxIdleConnsPerHost:   httpMaxConns.MaxIdleConnsPerHost,
+		MaxConnsPerHost:       httpMaxConns.MaxConnsPerHost,
 		IdleConnTimeout:       httpTimeOut.IdleConnTimeout,
 		ResponseHeaderTimeout: httpTimeOut.HeaderTimeout,
-		MaxConnsPerHost:       httpMaxConns.MaxConnsPerHost,
 	}
 
 	if config.InsecureSkipVerify {


### PR DESCRIPTION
Background:
If one oss client sends requests concurrently, there may occur a "connect: cannot assign requested address." error. This PR adds MaxConnsPerHost to limit the total number of connections per host, which avoids the host connections are exhausted.