### PR TITLE
flake: ListBuckets add Region field to response

### DIFF
--- a/oss/type.go
+++ b/oss/type.go
@@ -29,6 +29,7 @@ type BucketProperties struct {
 	Location     string    `xml:"Location"`     // Bucket datacenter
 	CreationDate time.Time `xml:"CreationDate"` // Bucket create time
 	StorageClass string    `xml:"StorageClass"` // Bucket storage class
+	Region       string    `xml:"Region"`       // Bucket region
 }
 
 // ListCloudBoxResult defines the result object from ListBuckets request
@@ -1616,10 +1617,10 @@ type Certificate struct {
 	ValidEndDate   string `xml:"ValidEndDate"`
 }
 
-//GetBucketResourceGroupResult define resource group for the bucket
+// GetBucketResourceGroupResult define resource group for the bucket
 type GetBucketResourceGroupResult BucketResourceGroupXml
 
-//PutBucketResourceGroup define the xml of bucket's resource group config
+// PutBucketResourceGroup define the xml of bucket's resource group config
 type PutBucketResourceGroup BucketResourceGroupXml
 
 // BucketResourceGroupXml define the information of the bucket's resource group


### PR DESCRIPTION
The raw response data of ListBuckets is as follows:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ListAllMyBucketsResult>
  <Owner>
    <ID>1834405290529728</ID>
    <DisplayName>1834405290529728</DisplayName>
  </Owner>
  <Buckets>
    <Bucket>
      <Comment></Comment>
      <CreationDate>2023-09-24T06:25:32.000Z</CreationDate>
      <ExtranetEndpoint>oss-cn-chengdu.aliyuncs.com</ExtranetEndpoint>
      <IntranetEndpoint>oss-cn-chengdu-internal.aliyuncs.com</IntranetEndpoint>
      <Location>oss-cn-chengdu</Location>
      <Name>bucket-name</Name>
      <Region>cn-chengdu</Region>
      <StorageClass>Standard</StorageClass>
    </Bucket>
  </Buckets>
</ListAllMyBucketsResult>
```
The `Region` field returns, but the defined struct does not include